### PR TITLE
bug removed .on rotating device home fragment opens

### DIFF
--- a/app/src/main/java/com/example/opencode20/MainActivity.java
+++ b/app/src/main/java/com/example/opencode20/MainActivity.java
@@ -36,8 +36,7 @@ public class MainActivity extends AppCompatActivity
         toggle.syncState();
         navigationView.setNavigationItemSelectedListener(this);
 
-        getSupportFragmentManager().beginTransaction()
-                    .replace(R.id.fragment_container,new HomeFragment()).commit();
+
     }
 
     @Override


### PR DESCRIPTION
__63__ 

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->
<!-- Add issue numbers both above and below this comment, do not remove __ or #-->

Fixes #63 

#### Short description of what this resolves:
bug removed when we rotate device home fragment opens.



#### Changes proposed in this pull request and/or Screenshots of changes:

-
-
-



